### PR TITLE
add support for building with FFmpeg 7

### DIFF
--- a/src/multimedia/ffmpeg/daudioencoderinterface_p.h
+++ b/src/multimedia/ffmpeg/daudioencoderinterface_p.h
@@ -74,14 +74,22 @@ private:
     decltype(av_packet_unref) *d_av_packet_unref { nullptr };
     decltype(avcodec_free_context) *d_avcodec_free_context { nullptr };
 
+#if LIBSWRESAMPLE_VERSION_INT >= AV_VERSION_INT(4, 5, 100)
+    decltype(swr_alloc_set_opts2) *d_swr_alloc_set_opts2 { nullptr };
+#else
     decltype(swr_alloc_set_opts) *d_swr_alloc_set_opts { nullptr };
+#endif
     decltype(swr_init) *d_swr_init { nullptr };
     decltype(swr_convert) *d_swr_convert { nullptr };
     decltype(swr_free) *d_swr_free { nullptr };
 
     decltype(av_audio_fifo_alloc) *d_av_audio_fifo_alloc { nullptr };
     decltype(av_frame_alloc) *d_av_frame_alloc { nullptr };
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(59, 24, 100)
+    decltype(av_channel_layout_default) *d_av_channel_layout_default { nullptr };
+#else
     decltype(av_get_default_channel_layout) *d_av_get_default_channel_layout { nullptr };
+#endif
     decltype(av_samples_alloc_array_and_samples) *d_av_samples_alloc_array_and_samples { nullptr };
     decltype(av_audio_fifo_space) *d_av_audio_fifo_space { nullptr };
     decltype(av_audio_fifo_write) *d_av_audio_fifo_write { nullptr };
@@ -109,6 +117,7 @@ private:
     QUrl outFilePath { "outAudioFile.aac" };
     int sampleRate { 48000 };
     int bitRate { 0 };
+    AVChannelLayout *ch_layout { nullptr };
     DAudioRecorder::AChannelsID channels { DAudioRecorder::CHANNELS_ID_STEREO };
     AVCodecID codec { AV_CODEC_ID_NONE };
 

--- a/src/multimediawidgets/engine/multimedia/player/dplaylistmodel.cpp
+++ b/src/multimediawidgets/engine/multimedia/player/dplaylistmodel.cpp
@@ -330,7 +330,11 @@ struct ModeMovieInfo DPlaylistModel::parseFromFile(const QFileInfo &fi, bool *ok
         mi.aCodeID   = audio_dec_ctx->codec_id;
         mi.aCodeRate = audio_dec_ctx->bit_rate;
         mi.aDigit    = audio_dec_ctx->format;
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(59, 24, 100)
+        mi.channels  = audio_dec_ctx->ch_layout.nb_channels;
+#else
         mi.channels  = audio_dec_ctx->channels;
+#endif
         mi.sampling  = audio_dec_ctx->sample_rate;
 
 #ifdef USE_TEST
@@ -1668,7 +1672,11 @@ ModeMovieInfo ModeMovieInfo::parseFromFile(const QFileInfo &fi, bool *ok)
     mi.aCodeID   = dec_ctx->codec_id;
     mi.aCodeRate = dec_ctx->bit_rate;
     mi.aDigit    = dec_ctx->format;
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(59, 24, 100)
+    mi.channels  = dec_ctx->ch_layout.nb_channels;
+#else
     mi.channels  = dec_ctx->channels;
+#endif
     mi.sampling  = dec_ctx->sample_rate;
 
     AVDictionaryEntry *tag = NULL;


### PR DESCRIPTION
Use the new ch_layout and swr_alloc_set_opts2 APIs added in FFmpeg/FFmpeg@cdba98bb80 .

The old APIs were removed in FFmpeg 7.