### PR TITLE
fix: ocr crash on sw64

### DIFF
--- a/src/ocr/ppocr/ppocr.cpp
+++ b/src/ocr/ppocr/ppocr.cpp
@@ -130,7 +130,7 @@ void PaddleOCRApp::initNet()
         recNet = new ncnn::Net;
         recNet->opt = option;
 
-#if !defined(_loongarch) && !defined(__loongarch__) && !defined(__loongarch64)
+#if !defined(_loongarch) && !defined(__loongarch__) && !defined(__loongarch64) && !defined(__sw_64__) && !defined(__mips__) 
         if (!gpuCanUse.empty()) {
             recNet->set_vulkan_device(gpuCanUse[0]);
             recNet->opt.use_vulkan_compute = true;


### PR DESCRIPTION
Same as 41111cecdaf79c26bdf2bfff9a26ecf1d4a929ff,
Block use GPU on sw64, wait for driver update.

Log: fix a crash issue.
Bug: https://pms.uniontech.com/bug-view-310269.html